### PR TITLE
feature: add health check endpoint at /api/health

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,7 @@
+// src/app/api/health/route.ts
+
+import { NextResponse } from "next/server";
+
+export async function GET() {
+    return NextResponse.json({ "status": "ok" })
+}


### PR DESCRIPTION
Implements issue #44 by creating a simple unauthenticated health check endpoint.

Additionally, it could be useful to have a more detailed health check endpoint (e.g., /api/status) that verifies critical dependencies such as MongoDB, Auth0, and Gemini API.
This would differentiate between a simple liveness probe (/api/health) and a readiness probe (/api/status).
I can create a follow-up issue for this if you think it makes sense. Thanks!